### PR TITLE
Update ContentModel.java ---> Scroll Event

### DIFF
--- a/extras/geometry-viewer/src/main/java/org/jlab/clas12/viewer/ContentModel.java
+++ b/extras/geometry-viewer/src/main/java/org/jlab/clas12/viewer/ContentModel.java
@@ -219,9 +219,9 @@ public class ContentModel {
             cameraXform2.setTx(cameraXform2.t.getX() - (0.01*event.getDeltaX()));  // -
             cameraXform2.setTy(cameraXform2.t.getY() + (0.01*event.getDeltaY()));  // -
         } else { // mouse wheel
-            double z = cameraPosition.getZ()-(event.getDeltaY()*0.2);
+            double z = cameraPosition.getZ()-(event.getDeltaY());//*0.2);
             z = Math.max(z,-10d*dimModel);
-            z = Math.min(z,0);
+            z = Math.min(z,10d*dimModel);
             cameraPosition.setZ(z);
         }
     };


### PR DESCRIPTION
Scrolling allows a zoom in and zoom out. In the coordinates of clas12 this was extremely slow and awkward as the forward carriage is in the +z hemisphere. I propose a change in the scroll event to give faster zoom and the ability for the camera to go into the +z facing out, without complicated rotations first. I would also argue the ZoomEvent and Translate camera (press on mouse wheel then mouse movement) should be changed to faster as well.

Results:
Can go from this:
![screenshot from 2016-06-30 09 33 54](https://cloud.githubusercontent.com/assets/12628970/16490809/402f4378-3ea9-11e6-8023-6598700c2f5c.png)

to this

![screenshot from 2016-06-30 09 34 31](https://cloud.githubusercontent.com/assets/12628970/16490823/49818788-3ea9-11e6-9f90-00ae858fcfac.png)

extremely quick and easily.

